### PR TITLE
upcoming events header on the homepage removed

### DIFF
--- a/events/templates/events/homepage.html
+++ b/events/templates/events/homepage.html
@@ -15,7 +15,6 @@
 
 <!-- Upcoming Events Section -->
 <div class="container my-5">
-    <h1 class="text-center animate__animated animate__fadeIn">Upcoming Events</h1>
     <div class="row">
         {% for event in events %}
         <div class="col-sm-6 col-md-4 col-lg-4 mb-4">


### PR DESCRIPTION
As per #3 upcoming events header on the homepage now removed.